### PR TITLE
Use lowercase instead of uppercase for ID

### DIFF
--- a/lib/wp-api-menus-v2.php
+++ b/lib/wp-api-menus-v2.php
@@ -341,7 +341,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 
             $item = (array) $menu_item;
             $menu_item = array(
-                'ID'       => abs( $item['ID'] ),
+                'id'       => abs( $item['ID'] ),
                 'order'    => (int) $item['menu_order'],
                 'parent'   => abs( $item['menu_item_parent'] ),
                 'title'    => $item['title'],


### PR DESCRIPTION
To match the standard for id's for the rest of the REST API.

Closes #14