### PR TITLE
Add check for JSON_API_VERSION constant

### DIFF
--- a/wp-api-menus.php
+++ b/wp-api-menus.php
@@ -48,9 +48,10 @@ if ( ! function_exists ( 'wp_rest_menus_init' ) ) :
 	 */
     function wp_rest_menus_init() {
 
-        if ( ! in_array( 'json-rest-api/plugin.php', get_option( 'active_plugins' ) ) ) {
-            $class = new WP_REST_Menus();
-            add_filter( 'rest_api_init', array( $class, 'register_routes' ) );
+        if ( ! defined( 'JSON_API_VERSION' ) &&
+             ! in_array( 'json-rest-api/plugin.php', get_option( 'active_plugins' ) ) ) {
+							 $class = new WP_REST_Menus();
+							 add_filter( 'rest_api_init', array( $class, 'register_routes' ) );
         } else {
             $class = new WP_JSON_Menus();
             add_filter( 'json_endpoints', array( $class, 'register_routes' ) );


### PR DESCRIPTION
In a mu-plugin installation of WP API 1.0 it will not show up under `active_plugins`.