### PR TITLE
Bug and Proposed Fix

### DIFF
--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -302,6 +302,9 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 				if ( array_key_exists ( $item->ID , $cache ) ) {
 					$formatted['children'] = array_reverse ( $cache[ $item->ID ] );
 				}
+				
+            	$formatted = apply_filters( 'rest_menus_format_menu_item', $formatted );
+				
 				if ( $item->menu_item_parent != 0 ) {
 					// Wait for parent to pick me up
 					if ( array_key_exists ( $item->menu_item_parent , $cache ) ) {


### PR DESCRIPTION
Hello.

Thanks for the the useful plugin. I started modifying it yesterday to add children to the output of the /menu-locations route, and I think I found a pretty big issue. After about the second sublevel, the code generates repeated nodes--basically walking *back up* the tree when it reaches a terminal child. I found this bug using "Testing Menu" from the WPtest data set (http://wptest.io/).

I came up with what I think is a good fix that simplifies the code. I'm a WordPress newbie, and my PHP is still stale from years of working only in JavaScript. So I could be wrong. But, here's what I found:

Looks like the output of wp_get_nav_menu_items() is sequenced correctly, so there's no need to do any sorting. Just *reverse* the array result, use a cache array to hold children until a parent comes along, and run a simple loop to build menu level arrays. Reverse generated arrays for completed menu levels, and send the response. Output looks correct in my tests.

Again, as I'm a newbie, please don't hesitate to send feedback so I can learn :)

Cheers!