### PR TITLE
Add slug field to menu items.

### DIFF
--- a/includes/wp-api-menus-v1.php
+++ b/includes/wp-api-menus-v1.php
@@ -274,6 +274,7 @@ if ( ! class_exists( 'WP_JSON_Menus' ) ) :
 				'description' => $item['description'],
 				'object_id'   => abs( $item['object_id'] ),
 				'object'      => $item['object'],
+                'object_slug' => get_post($item['object_id'])->post_name,
 				'type'        => $item['type'],
 				'type_label'  => $item['type_label'],
 			);

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -302,9 +302,9 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 				if ( array_key_exists ( $item->ID , $cache ) ) {
 					$formatted['children'] = array_reverse ( $cache[ $item->ID ] );
 				}
-				
+
             	$formatted = apply_filters( 'rest_menus_format_menu_item', $formatted );
-				
+
 				if ( $item->menu_item_parent != 0 ) {
 					// Wait for parent to pick me up
 					if ( array_key_exists ( $item->menu_item_parent , $cache ) ) {
@@ -379,6 +379,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 'description' => $item['description'],
                 'object_id'   => abs( $item['object_id'] ),
                 'object'      => $item['object'],
+                'object_slug' => get_post($item['object_id'])->post_name,
                 'type'        => $item['type'],
                 'type_label'  => $item['type_label'],
             );


### PR DESCRIPTION
As noted in #18 it's helpfull to get the slug of the referenced
object in some cases (e.g. custom routing).

Now every item and possible children have an `object_slug` field.
In case of custom links it just returns the items slug since the
id refers to the item it self.

Note that the v1 implementation isn't tested.

Closes #18