### PR TITLE
Adding object_slug to the items array returned in locations

### DIFF
--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -294,6 +294,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 					'description' => $item->description,
 					'object_id'   => abs( $item->object_id ),
 					'object'      => $item->object,
+					'object_slug' => get_post($item->object_id)->post_name,
 					'type'        => $item->type,
 					'type_label'  => $item->type_label,
 					'children'    => array(),


### PR DESCRIPTION
An extension from this idea: https://github.com/unfulvio/wp-api-menus/issues/18 to add in the object_slug (i.e. the relative target href) to menu item object return in the array when a location query is used.
