### PR TITLE
Fix namespace in links

### DIFF
--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -131,7 +131,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
         public function get_menu( $request ) {
 
             $id             = (int) $request['id'];
-            $rest_url       = get_rest_url() . self::get_api_namespace() . '/menus/';
+            $rest_url       = get_rest_url() . self::get_plugin_namespace() . '/menus/';
             $wp_menu_object = $id ? wp_get_nav_menu_object( $id ) : array();
             $wp_menu_items  = $id ? wp_get_nav_menu_items( $id ) : array();
 
@@ -225,7 +225,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 
             $locations        = get_nav_menu_locations();
             $registered_menus = get_registered_nav_menus();
-	        $rest_url         = get_rest_url() . self::get_api_namespace() . '/menu-locations/';
+	        $rest_url         = get_rest_url() . self::get_plugin_namespace() . '/menu-locations/';
             $rest_menus       = array();
 
             if ( $locations && $registered_menus ) :


### PR DESCRIPTION
I notice some of the links were incorrect. They should use the plugin namespace and not the api namespace.

See for example /wp-json/wp-api-menus/v2/menu-locations

(note I closed this duplicate PR https://github.com/unfulvio/wp-api-menus/pull/40 as I opened it from master branch, and wanted to make some other changes there)