### PR TITLE
Fix rare instance of a PHP notice being thrown

### DIFF
--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -369,7 +369,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
         public function format_menu_item( $menu_item, $children = false, $menu = array() ) {
 
             $item = (array) $menu_item;
-			$object_post = get_post( $item['object_id'] );
+                $object_post = get_post( $item['object_id'] );
 
 
             $menu_item = array(

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -369,6 +369,8 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
         public function format_menu_item( $menu_item, $children = false, $menu = array() ) {
 
             $item = (array) $menu_item;
+			$object_post = get_post( $item['object_id'] );
+
 
             $menu_item = array(
                 'id'          => abs( $item['ID'] ),
@@ -383,7 +385,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 'description' => $item['description'],
                 'object_id'   => abs( $item['object_id'] ),
                 'object'      => $item['object'],
-                'object_slug' => get_post( $item['object_id'] )->post_name,
+                'object_slug' => !empty($object_post) ? $object_post->post_name : null,
                 'type'        => $item['type'],
                 'type_label'  => $item['type_label'],
             );

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -369,7 +369,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
         public function format_menu_item( $menu_item, $children = false, $menu = array() ) {
 
             $item = (array) $menu_item;
-                $object_post = get_post( $item['object_id'] );
+            $object_post = get_post( $item['object_id'] );
 
 
             $menu_item = array(


### PR DESCRIPTION
PHP Notice:  Trying to get property of non-object in /data/wordpress/htdocs/wp-content/plugins/wp-api-menus/includes/wp-api-menus-v2.php on line 387

It returns `null` in the offending item when displayed in the REST response.