### PR TITLE
Support for 5.5 `permission_callback`

### DIFF
--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -55,7 +55,8 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
             register_rest_route( self::get_plugin_namespace(), '/menus', array(
                 array(
                     'methods'  => WP_REST_Server::READABLE,
-                    'callback' => array( $this, 'get_menus' ),
+	                'callback' => array( $this, 'get_menus' ),
+	                'permission_callback' => '__return_true',
                 )
             ) );
 
@@ -63,6 +64,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 array(
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu' ),
+	                'permission_callback' => '__return_true',
                     'args'     => array(
                         'context' => array(
                         'default' => 'view',
@@ -75,6 +77,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 array(
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu_locations' ),
+	                'permission_callback' => '__return_true',
                 )
             ) );
 
@@ -82,6 +85,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 array(
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu_location' ),
+	                'permission_callback' => '__return_true',
                 )
             ) );
         }

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -55,7 +55,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
             register_rest_route( self::get_plugin_namespace(), '/menus', array(
                 array(
                     'methods'  => WP_REST_Server::READABLE,
-	                'callback' => array( $this, 'get_menus' ),
+                    'callback' => array( $this, 'get_menus' ),
                     'permission_callback' => '__return_true',
                 )
             ) );

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 array(
                     'methods'  => WP_REST_Server::READABLE,
 	                'callback' => array( $this, 'get_menus' ),
-	                'permission_callback' => '__return_true',
+                    'permission_callback' => '__return_true',
                 )
             ) );
 
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 array(
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu' ),
-	                'permission_callback' => '__return_true',
+                    'permission_callback' => '__return_true',
                     'args'     => array(
                         'context' => array(
                         'default' => 'view',
@@ -77,7 +77,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 array(
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu_locations' ),
-	                'permission_callback' => '__return_true',
+                    'permission_callback' => '__return_true',
                 )
             ) );
 
@@ -85,7 +85,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 array(
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu_location' ),
-	                'permission_callback' => '__return_true',
+                    'permission_callback' => '__return_true',
                 )
             ) );
         }


### PR DESCRIPTION
Add `permission_callback` as it's a required field in WordPress >= 5.5, fixes #57 