### PR TITLE
Fixed permission_callback issue with WP5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-#### 1.3.1 (03 Oct 2016)
+#### 1.3.2 (03 Oct 2016)
+ * Fix (V2): Fix V2 register_rest_route compability issue with WP 5.5. (Missing permission_callback callback)
+
+ #### 1.3.1 (03 Oct 2016)
  * Tweak: The `object_slug` property is now available to get the slug for relative URLs - props @Fahrradflucht
 
 #### 1.3.0 (25 Feb 2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#### 1.3.2 (03 Oct 2016)
+#### 1.3.2 (12 August 2020)
  * Fix (V2): Fix V2 register_rest_route compability issue with WP 5.5. (Missing permission_callback callback)
 
  #### 1.3.1 (03 Oct 2016)

--- a/wp-api-menus.php
+++ b/wp-api-menus.php
@@ -4,7 +4,7 @@
  * Plugin URI:  https://github.com/nekojira/wp-api-menus
  * Description: Extends WP API with WordPress menu routes.
  *
- * Version:     1.3.1
+ * Version:     1.3.2
  *
  * Author:      Fulvio Notarstefano
  * Author URI:  https://github.com/unfulvio


### PR DESCRIPTION
Fixed issue with Wordpress 5.5. requiring `'permission_callback' => '__return_true'` on `register_rest_route`  

Bumped version and added not to change-log