### PR TITLE
Add query params for control over including items and fetching specific menu list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.3.1 (03 Oct 2016)
+#### 1.3.1 (03 Oct 2016)
  * Tweak: The `object_slug` property is now available to get the slug for relative URLs - props @Fahrradflucht
 
 #### 1.3.0 (25 Feb 2016)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - `/menus` list of every registered menu.
 - `/menus/<id>` data for a specific menu.
+- `/menus?include=<id>,<id2>,<id3>` data for a set of menus
 - `/menu-locations` list of all registered theme locations.
 - `/menu-locations/<location>` data for menu in specified menu in theme location. 
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@
 
 - `/menus` list of every registered menu.
     - Accepted parameters:
-        - `include_menu_items`: get the items assigned to each Menu. <i>Default: true</i>
+        - `include_menu_items`: get the items assigned to each Menu. <i>Default: false</i>
         - `include=<id>,<id2>,<id3>`: request a specific set of Menus
 - `/menus/<id>` data for a specific menu.
+        - `include_menu_items`: get the items assigned to this Menu. <i>Default: true</i>
 - `/menu-locations` list of all registered theme locations.
 - `/menu-locations/<location>` data for menu in specified menu in theme location. 
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@
 #### New routes available:
 
 - `/menus` list of every registered menu.
+    - Accepted parameters:
+        - `include_menu_items`: get the items assigned to each Menu. <i>Default: true</i>
+        - `include=<id>,<id2>,<id3>`: request a specific set of Menus
 - `/menus/<id>` data for a specific menu.
-- `/menus?include=<id>,<id2>,<id3>` data for a set of menus
 - `/menu-locations` list of all registered theme locations.
 - `/menu-locations/<location>` data for menu in specified menu in theme location. 
 

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -410,7 +410,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 'description' => $item['description'],
                 'object_id'   => abs( $item['object_id'] ),
                 'object'      => $item['object'],
-                'object_slug' => get_post( $item['object_id'] )->post_name,
+                'object_slug' => $item['post_name'],
                 'type'        => $item['type'],
                 'type_label'  => $item['type_label']
             );

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -118,7 +118,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
         public static function get_menus($request =false) {
             if(!$request)
                 return [];
-                
+
             $params = $request->get_params();
             
             $query_args = [];
@@ -128,16 +128,14 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
             $rest_url = trailingslashit( get_rest_url() . self::get_plugin_namespace() . '/menus/' );
             $wp_menus = wp_get_nav_menus($query_args);
 
-            // check if we should also include the actual menu
-            $include_items= false;
-            if(isset($params['include_menu_items']) && ((bool)$params['include_menu_items'] == true))
-                $include_items = true;
+            // check if we should also include the actual menu; default to true
+            $include_items= (isset($params['include_menu_items']) && ((bool)$params['include_menu_items'] == false)) ? false : true;
             
             $i = 0;
             $rest_menus = array();
             foreach ( $wp_menus as $wp_menu ) :
 
-                $rest_menus[ $i ] = $this->get_menu(['id'=>$wp_menu->term_id],$include_items);
+                $rest_menus[ $i ] = (new WP_REST_Menus)->get_menu(['id'=>$wp_menu->term_id],$include_items);
                 $i ++;
             endforeach;
 
@@ -398,8 +396,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
         public function format_menu_item( $menu_item, $children = false, $menu = array() ) {
 
             $item = (array) $menu_item;
-            $id = abs($item['ID']);
-            $icon = get_post_meta($id, 'menu-item-icon', true);
+            $id = (int)$item['ID'];
             $menu_item = array(
                 'id'          => abs( $item['ID'] ),
                 'order'       => (int) $item['menu_order'],
@@ -415,9 +412,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                 'object'      => $item['object'],
                 'object_slug' => get_post( $item['object_id'] )->post_name,
                 'type'        => $item['type'],
-                'type_label'  => $item['type_label'],
-                'icon'        => $icon,  
-
+                'type_label'  => $item['type_label']
             );
 
             if ( $children === true && ! empty( $menu ) ) {

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -115,7 +115,10 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @since  1.2.0
          * @return array All registered menus
          */
-        public static function get_menus($request) {
+        public static function get_menus($request =false) {
+            if(!$request)
+                return [];
+                
             $params = $request->get_params();
             
             $query_args = [];

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -128,14 +128,14 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
             $rest_url = trailingslashit( get_rest_url() . self::get_plugin_namespace() . '/menus/' );
             $wp_menus = wp_get_nav_menus($query_args);
 
-            // check if we should also include the actual menu; default to true
-            $include_items= (isset($params['include_menu_items']) && ((bool)$params['include_menu_items'] == false)) ? false : true;
+            // check if we should also include the actual menu; default to false
+            $include_items= (isset($params['include_menu_items']) && ($params['include_menu_items'] == "true")) ? true : false;
             
             $i = 0;
             $rest_menus = array();
             foreach ( $wp_menus as $wp_menu ) :
 
-                $rest_menus[ $i ] = (new WP_REST_Menus)->get_menu(['id'=>$wp_menu->term_id],$include_items);
+                $rest_menus[ $i ] = array_merge((array)$wp_menu,(new WP_REST_Menus)->get_menu(['id'=>$wp_menu->term_id],$include_items));
                 $i ++;
             endforeach;
 
@@ -154,8 +154,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 
             $id             = (int) $request['id'];
             $rest_url       = get_rest_url() . self::get_api_namespace() . '/menus/';
-            $wp_menu_object = $id ? wp_get_nav_menu_object( $id ) : array();
-            $wp_menu_items  = $id ? wp_get_nav_menu_items( $id ) : array();
+            $wp_menu_object = $id ? wp_get_nav_menu_object( $id ) : array();            
 
             $rest_menu = array();
 
@@ -170,6 +169,8 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 
 
                 if($include_items){
+                    $wp_menu_items  = $id ? wp_get_nav_menu_items( $id ) : array();
+
                     $rest_menu_items = array();
                     foreach ( $wp_menu_items as $item_object ) {
                     


### PR DESCRIPTION
We use the plugin on a few sites that have a lot of menus, so it isn't always efficient to get all of them with `/menus` but it also wouldn't be very efficient to get them all with individual REST calls.  So, we've modified the plugin to support parameters on the `/menus` route that allow us to define the menus we want and whether the API should also return the items from those menus.

So, you can call this and get Menus 38, 475 and 832 along with all the items assigned to them:
`/wp-json/wp-api-menus/v2/menus?include=38,475,832&include_menu_items=true`

You can also fetch Menu 38 using the `/menus/<id>` route but get it's top-level data without including the nav items:
`/wp-json/wp-api-menus/v2/menus/38?include_menu_items=false`

These two tweaks have let us have a lot more control over what data we load and when (especially useful in scenarios using GraphQL)

I _believe_ this is fully backward compatible and properly defaults to current behaviors so we don't break existing queries.