### PR TITLE
Release/1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ sftp-config.json
 /build
 /node_modules/
 /vendor/
+/wordpress/
 composer.lock
 
 ### Tests ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+#### 1.4.0 (28 February 2022)
+* Mark menus as deprecated via `doing_it_wrong()` in favor of WordPress' core menus endpoints in WP >= 5.9 - props @thefrosty
+* Allow continued use of legacy menus via filter: `rest_menus_allow_legacy_menus`:
+  ```php
+     add_filter( 'rest_menus_allow_legacy_menus', '__return_true' );
+  ``` 
+
 #### 1.3.2 (12 August 2020)
- * Fix (V2): Fix V2 register_rest_route compatibility issue with WP 5.5. (Missing permission_callback arg)
+* Fix (V2): Fix V2 register_rest_route compatibility issue with WP 5.5. (Missing permission_callback arg)
 
 #### 1.3.1 (03 Oct 2016)
  * Tweak: The `object_slug` property is now available to get the slug for relative URLs - props @Fahrradflucht

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,24 @@
   "name": "unfulvio/wp-api-menus",
   "description": "Extends WordPress WP API with menu routes.",
   "type": "wordpress-plugin",
-  "version": "1.3.2",
-  "keywords": ["wordpress", "wp", "wp-api", "wp-rest-api", "api", "json"],
+  "version": "1.4.0",
+  "keywords": [
+    "rest-api",
+    "wordpress",
+    "wp-rest-api",
+    "json"
+  ],
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "roots/wordpress-core-installer": true
+    },
+    "optimize-autoloader": true,
+    "platform": {
+      "php": "5.6"
+    },
+    "sort-packages": true
+  },
   "homepage": "https://github.com/unfulvio/wp-api-menus",
   "license": "GPLv2.0+",
   "authors": [
@@ -21,7 +37,10 @@
     }
   ],
   "require": {
-    "php": ">=5.3.2",
+    "php": ">=5.6",
     "composer/installers": "~1.0"
+  },
+  "require-dev": {
+    "roots/wordpress": "~5.9"
   }
 }

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -22,18 +22,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
      */
     class WP_REST_Menus {
 
-
-	    /**
-	     * Get WP API namespace.
-	     *
-	     * @since 1.2.0
-	     * @return string
-	     */
-        public static function get_api_namespace() {
-            return 'wp/v2';
-        }
-
-
 	    /**
 	     * Get WP API Menus namespace.
 	     *
@@ -57,7 +45,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menus' ),
                     'permission_callback' => '__return_true',
-	                'schema' => array( 'deprecated' => true ),
                 )
             ) );
 
@@ -66,7 +53,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu' ),
                     'permission_callback' => '__return_true',
-                    'schema' => array( 'deprecated' => true ),
                     'args' => array(
 	                    'context' => array(
 		                    'default' => 'view',
@@ -80,7 +66,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu_locations' ),
                     'permission_callback' => '__return_true',
-                    'schema' => array( 'deprecated' => true ),
                 )
             ) );
 
@@ -89,11 +74,9 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu_location' ),
                     'permission_callback' => '__return_true',
-                    'schema' => array( 'deprecated' => true ),
                 )
             ) );
         }
-
 
         /**
          * Get menus.

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @since  1.2.0
          * @return array All registered menus
          */
-        public static function get_menus() {
+        public function get_menus() {
 	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $rest_url = trailingslashit( get_rest_url() . self::get_plugin_namespace() . '/menus/' );
             $wp_menus = wp_get_nav_menus();
@@ -212,7 +212,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @param  $request
          * @return array All registered menus locations
          */
-        public static function get_menu_locations( $request ) {
+        public function get_menu_locations( $request ) {
 	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $locations        = get_nav_menu_locations();
             $registered_menus = get_registered_nav_menus();

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -23,6 +23,17 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
     class WP_REST_Menus {
 
 	    /**
+	     * Mapped route replacements.
+	     * @var string[] $replacements
+	     */
+		private $replacements = array(
+			'/menus' => '/wp/v2/menus',
+			'/menus/(?P<id>\d+)' => '/wp/v2/menus/(?P<id>[\d]+)',
+			'/menu-locations' => '/wp/v2/menu-locations',
+			'/menu-locations/(?P<location>[a-zA-Z0-9_-]+)' => '/wp/v2/menu-locations/(?P<location>[\w-]+)',
+		);
+
+	    /**
 	     * Get WP API Menus namespace.
 	     *
 	     * @since 1.2.1
@@ -32,7 +43,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
 		    return 'wp-api-menus/v2';
 	    }
 
-
         /**
          * Register menu routes for WP API v2.
          *
@@ -40,42 +50,42 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          */
         public function register_routes() {
 
-            register_rest_route( self::get_plugin_namespace(), '/menus', array(
-                array(
-                    'methods'  => WP_REST_Server::READABLE,
-                    'callback' => array( $this, 'get_menus' ),
-                    'permission_callback' => '__return_true',
-                )
-            ) );
+	        $this->register_rest_route( '/menus', array(
+		        array(
+			        'methods'             => WP_REST_Server::READABLE,
+			        'callback'            => array( $this, 'get_menus' ),
+			        'permission_callback' => '__return_true',
+		        )
+	        ) );
 
-            register_rest_route( self::get_plugin_namespace(), '/menus/(?P<id>\d+)', array(
-                array(
-                    'methods'  => WP_REST_Server::READABLE,
-                    'callback' => array( $this, 'get_menu' ),
-                    'permission_callback' => '__return_true',
-                    'args' => array(
-	                    'context' => array(
-		                    'default' => 'view',
-	                    ),
-                    ),
-                )
-            ) );
+	        $this->register_rest_route( '/menus/(?P<id>\d+)', array(
+		        array(
+			        'methods'             => WP_REST_Server::READABLE,
+			        'callback'            => array( $this, 'get_menu' ),
+			        'permission_callback' => '__return_true',
+			        'args'                => array(
+				        'context' => array(
+					        'default' => 'view',
+				        ),
+			        ),
+		        )
+	        ) );
 
-            register_rest_route( self::get_plugin_namespace(), '/menu-locations', array(
-                array(
-                    'methods'  => WP_REST_Server::READABLE,
-                    'callback' => array( $this, 'get_menu_locations' ),
-                    'permission_callback' => '__return_true',
-                )
-            ) );
+	        $this->register_rest_route( '/menu-locations', array(
+		        array(
+			        'methods'             => WP_REST_Server::READABLE,
+			        'callback'            => array( $this, 'get_menu_locations' ),
+			        'permission_callback' => '__return_true',
+		        )
+	        ) );
 
-            register_rest_route( self::get_plugin_namespace(), '/menu-locations/(?P<location>[a-zA-Z0-9_-]+)', array(
-                array(
-                    'methods'  => WP_REST_Server::READABLE,
-                    'callback' => array( $this, 'get_menu_location' ),
-                    'permission_callback' => '__return_true',
-                )
-            ) );
+	        $this->register_rest_route( '/menu-locations/(?P<location>[a-zA-Z0-9_-]+)', array(
+		        array(
+			        'methods'             => WP_REST_Server::READABLE,
+			        'callback'            => array( $this, 'get_menu_location' ),
+			        'permission_callback' => '__return_true',
+		        )
+	        ) );
         }
 
         /**
@@ -85,7 +95,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @return array All registered menus
          */
         public function get_menus() {
-	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $rest_url = trailingslashit( get_rest_url() . self::get_plugin_namespace() . '/menus/' );
             $wp_menus = wp_get_nav_menus();
 
@@ -120,7 +129,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @return array Menu data
          */
         public function get_menu( $request ) {
-	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $id             = (int) $request['id'];
             $rest_url       = get_rest_url() . self::get_plugin_namespace() . '/menus/';
             $wp_menu_object = $id ? wp_get_nav_menu_object( $id ) : array();
@@ -213,7 +221,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @return array All registered menus locations
          */
         public function get_menu_locations( $request ) {
-	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $locations        = get_nav_menu_locations();
             $registered_menus = get_registered_nav_menus();
 	        $rest_url         = get_rest_url() . self::get_plugin_namespace() . '/menu-locations/';
@@ -249,7 +256,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @return array The menu for the corresponding location
          */
         public function get_menu_location( $request ) {
-	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $params     = $request->get_params();
             $location   = $params['location'];
             $locations  = get_nav_menu_locations();
@@ -388,6 +394,17 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
             return apply_filters( 'rest_menus_format_menu_item', $menu_item );
         }
 
+	    /**
+	     * Registers our REST API route.
+	     *
+	     * @param string $route     The base URL for route you are adding.
+	     * @param array  $args      Optional. Either an array of options for the endpoint, or an array of arrays for
+	     *                          multiple methods. Default empty array.
+	     */
+	    private function register_rest_route( $route, $args = array() ) {
+		    _wp_rest_menus_doing_it_wrong( __METHOD__, $route, $this->replacements[ $route ] );
+		    register_rest_route( self::get_plugin_namespace(), $route, $args );
+	    }
     }
 
 endif;

--- a/includes/wp-api-menus-v2.php
+++ b/includes/wp-api-menus-v2.php
@@ -57,6 +57,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menus' ),
                     'permission_callback' => '__return_true',
+	                'schema' => array( 'deprecated' => true ),
                 )
             ) );
 
@@ -65,10 +66,11 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu' ),
                     'permission_callback' => '__return_true',
-                    'args'     => array(
-                        'context' => array(
-                        'default' => 'view',
-                        ),
+                    'schema' => array( 'deprecated' => true ),
+                    'args' => array(
+	                    'context' => array(
+		                    'default' => 'view',
+	                    ),
                     ),
                 )
             ) );
@@ -78,6 +80,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu_locations' ),
                     'permission_callback' => '__return_true',
+                    'schema' => array( 'deprecated' => true ),
                 )
             ) );
 
@@ -86,6 +89,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => array( $this, 'get_menu_location' ),
                     'permission_callback' => '__return_true',
+                    'schema' => array( 'deprecated' => true ),
                 )
             ) );
         }
@@ -98,7 +102,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @return array All registered menus
          */
         public static function get_menus() {
-
+	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $rest_url = trailingslashit( get_rest_url() . self::get_plugin_namespace() . '/menus/' );
             $wp_menus = wp_get_nav_menus();
 
@@ -133,7 +137,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @return array Menu data
          */
         public function get_menu( $request ) {
-
+	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $id             = (int) $request['id'];
             $rest_url       = get_rest_url() . self::get_plugin_namespace() . '/menus/';
             $wp_menu_object = $id ? wp_get_nav_menu_object( $id ) : array();
@@ -226,7 +230,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @return array All registered menus locations
          */
         public static function get_menu_locations( $request ) {
-
+	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $locations        = get_nav_menu_locations();
             $registered_menus = get_registered_nav_menus();
 	        $rest_url         = get_rest_url() . self::get_plugin_namespace() . '/menu-locations/';
@@ -262,7 +266,7 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
          * @return array The menu for the corresponding location
          */
         public function get_menu_location( $request ) {
-
+	        _wp_rest_menus_doing_it_wrong(__METHOD__);
             $params     = $request->get_params();
             $location   = $params['location'];
             $locations  = get_nav_menu_locations();
@@ -401,8 +405,6 @@ if ( ! class_exists( 'WP_REST_Menus' ) ) :
             return apply_filters( 'rest_menus_format_menu_item', $menu_item );
         }
 
-
     }
-
 
 endif;

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === WP API Menus ===
 Contributors: nekojira, austyfrosty
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=P64V9NTEYFKDL
-Tags: wp-api, wp-rest-api, json-rest-api, json, menus, rest, api, menu-routes
-Requires at least: 3.6.0
-Tested up to: 5.5.0
-Stable tag: 1.3.2
+Tags: deprecated, wp-api, wp-rest-api, json-rest-api, json, menus, rest, api, menu-routes
+Requires at least: 5.8.0
+Tested up to: 5.9.1
+Stable tag: 1.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -33,12 +33,9 @@ In V2 the routes by default are at `wp-json/wp-api-menus/v2/` (e.g. `wp-json/wp-
 
 == Installation ==
 
-This plugin requires having [WP API](https://wordpress.org/plugins/json-rest-api/) installed and activated or it won't be of any use.
-
 Install the plugin as you would with any WordPress plugin in your `wp-content/plugins/` directory or equivalent.
 
 Once installed, activate WP API Menus from WordPress plugins dashboard page and you're ready to go, WP API will respond to new routes and endpoints to your registered menus.
-
 
 == Frequently Asked Questions ==
 
@@ -57,6 +54,10 @@ However, menu data organization in json is a bit arbitrary and subjective, and t
 Nothing to show really, this plugin has no settings or frontend, it just extends WP API with new routes. It's up to you how to use them :)
 
 == Changelog ==
+
+= 1.4.0 =
+* Mark menus as deprecated via `doing_it_wrong()` in favor of WordPress' core menus endpoints in WP >= 5.9 - props @thefrosty
+* Allow continued use of legacy menus via filter: `rest_menus_allow_legacy_menus`.
 
 = 1.3.2 =
 * Fix: Address V2 register_rest_route compatibility issue with WP 5.5 (missing permission_callback arg) - props @thefrosty
@@ -103,6 +104,9 @@ Nothing to show really, this plugin has no settings or frontend, it just extends
 
 == Upgrade Notice ==
 
-= 1.2.1 =
+= 1.4.0 =
+All WP API Menu routes are now marked as "deprecated", you should use WordPress' core menu endpoints. To continue 
+using legacy menus, you can filter `rest_menus_allow_legacy_menus` to return true.
 
+= 1.2.1 =
 API V2 only: mind lowercase `id` instead of uppercase `ID` in API responses, to match the standard for `id` used across WP REST API.

--- a/wp-api-menus.php
+++ b/wp-api-menus.php
@@ -66,12 +66,14 @@ if ( ! function_exists( '_wp_rest_menus_doing_it_wrong' ) ) :
 	 * Mark a function as "deprecated" using doing_it_wrong().
 	 *
 	 * @param string $function
+	 * @param string $route
+	 * @param string $replacement
 	 *
 	 * @access private
 	 * @since 1.4.0
 	 * @uses _doing_it_wrong()
 	 */
-	function _wp_rest_menus_doing_it_wrong( $function ) {
+	function _wp_rest_menus_doing_it_wrong( $function, $route, $replacement ) {
 		if (
 			_wp_rest_menus_allow_legacy_menus() ||
 			is_wp_version_compatible( '5.9' ) && _wp_rest_menus_allow_legacy_menus()
@@ -83,8 +85,9 @@ if ( ! function_exists( '_wp_rest_menus_doing_it_wrong' ) ) :
 			$function,
 			sprintf(
 			/* translators: 1: The REST API route namespace, 2: The plugin version. */
-				__( 'All custom menu routes under %1$s are deprecated in WordPress >= 5.9. Please use WordPres cores menu route(s).' ),
-				'<code>' . WP_REST_Menus::get_plugin_namespace() . '</code>'
+				__( 'The REST API Menu route %1$s is "deprecated". Please use WordPres cores menu route replacement found in WP >= 5.9: %2$s' ),
+				sprintf('<code>%1$s%2$s</code>', WP_REST_Menus::get_plugin_namespace(), $route),
+				'<code>' . $replacement . '</code>'
 			),
 			'1.4.0'
 		);

--- a/wp-api-menus.php
+++ b/wp-api-menus.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/unfulvio/wp-api-menus
  * Description: Extends WP API with WordPress menu routes.
  * Version: 1.4.0
- * Requires at least: 5.9
+ * Requires at least: 5.8
  * Tested up to: 5.9.1
  * Requires PHP: 5.6
  * Author: Fulvio Notarstefano

--- a/wp-api-menus.php
+++ b/wp-api-menus.php
@@ -72,7 +72,10 @@ if ( ! function_exists( '_wp_rest_menus_doing_it_wrong' ) ) :
 	 * @uses _doing_it_wrong()
 	 */
 	function _wp_rest_menus_doing_it_wrong( $function ) {
-		if ( ! is_wp_version_compatible( '5.9' ) || _wp_rest_menus_allow_legacy_menus() ) {
+		if (
+			_wp_rest_menus_allow_legacy_menus() ||
+			is_wp_version_compatible( '5.9' ) && _wp_rest_menus_allow_legacy_menus()
+		) {
 			return;
 		}
 

--- a/wp-api-menus.php
+++ b/wp-api-menus.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Plugin Name: WP REST API Menus
- * Plugin URI:  https://github.com/nekojira/wp-api-menus
+ * Plugin URI: https://github.com/unfulvio/wp-api-menus
  * Description: Extends WP API with WordPress menu routes.
- *
- * Version:     1.3.2
- *
- * Author:      Fulvio Notarstefano
- * Author URI:  https://github.com/unfulvio
- *
+ * Version: 1.4.0
+ * Requires at least: 5.9
+ * Tested up to: 5.9.1
+ * Requires PHP: 5.6
+ * Author: Fulvio Notarstefano
+ * Author URI: https://github.com/unfulvio
  * Text Domain: wp-api-menus
  *
  * @package WP_API_Menus
@@ -39,8 +39,7 @@ include_once 'includes/wp-api-menus-v1.php';
 // WP API v2.
 include_once 'includes/wp-api-menus-v2.php';
 
-if ( ! function_exists ( 'wp_rest_menus_init' ) ) :
-
+if ( ! function_exists( 'wp_rest_menus_init' ) ) :
 	/**
 	 * Init JSON REST API Menu routes.
 	 *
@@ -48,9 +47,11 @@ if ( ! function_exists ( 'wp_rest_menus_init' ) ) :
 	 */
 	function wp_rest_menus_init() {
 
-        if ( ! defined( 'JSON_API_VERSION' ) && ! in_array( 'json-rest-api/plugin.php', get_option( 'active_plugins' ) ) ) {
+		if ( ! defined( 'JSON_API_VERSION' ) &&
+		     ! in_array( 'json-rest-api/plugin.php', get_option( 'active_plugins', array() ) )
+		) {
 			$class = new WP_REST_Menus();
-			 add_filter( 'rest_api_init', array( $class, 'register_routes' ) );
+			add_filter( 'rest_api_init', array( $class, 'register_routes' ) );
 		} else {
 			$class = new WP_JSON_Menus();
 			add_filter( 'json_endpoints', array( $class, 'register_routes' ) );
@@ -58,5 +59,29 @@ if ( ! function_exists ( 'wp_rest_menus_init' ) ) :
 	}
 
 	add_action( 'init', 'wp_rest_menus_init' );
+endif;
 
+if ( ! function_exists( '_wp_rest_menus_doing_it_wrong' ) ) :
+	/**
+	 * Mark a function as "deprecated" using doing_it_wrong().
+	 *
+	 * @param string $function
+	 * @access private
+	 * @uses _doing_it_wrong()
+	 */
+	function _wp_rest_menus_doing_it_wrong( $function ) {
+		if ( ! is_wp_version_compatible( '5.9' ) ) {
+			return;
+		}
+
+		_doing_it_wrong(
+			$function,
+			sprintf(
+			/* translators: 1: The REST API route namespace, 2: The plugin version. */
+				__( 'All custom menu routes under %1$s are deprecated in WordPress >= 5.9. Please use WordPres cores menu route(s).' ),
+				'<code>' . self::get_plugin_namespace() . '</code>'
+			),
+			'1.4.0'
+		);
+	}
 endif;

--- a/wp-api-menus.php
+++ b/wp-api-menus.php
@@ -66,11 +66,13 @@ if ( ! function_exists( '_wp_rest_menus_doing_it_wrong' ) ) :
 	 * Mark a function as "deprecated" using doing_it_wrong().
 	 *
 	 * @param string $function
+	 *
 	 * @access private
+	 * @since 1.4.0
 	 * @uses _doing_it_wrong()
 	 */
 	function _wp_rest_menus_doing_it_wrong( $function ) {
-		if ( ! is_wp_version_compatible( '5.9' ) ) {
+		if ( ! is_wp_version_compatible( '5.9' ) || _wp_rest_menus_allow_legacy_menus() ) {
 			return;
 		}
 
@@ -83,5 +85,25 @@ if ( ! function_exists( '_wp_rest_menus_doing_it_wrong' ) ) :
 			),
 			'1.4.0'
 		);
+	}
+endif;
+
+if ( ! function_exists( '_wp_rest_menus_allow_legacy_menus' ) ) :
+	/**
+	 * Allow legacy menus "filter".
+	 *
+	 * @return bool
+	 * @since 1.4.0
+	 * @access private
+	 */
+	function _wp_rest_menus_allow_legacy_menus() {
+		/**
+		 * Allow legacy menus.
+		 *
+		 * @param bool $allow_legacy_menus
+		 *
+		 * @return bool
+		 */
+		return apply_filters( 'rest_menus_allow_legacy_menus', false ) === true;
 	}
 endif;

--- a/wp-api-menus.php
+++ b/wp-api-menus.php
@@ -81,7 +81,7 @@ if ( ! function_exists( '_wp_rest_menus_doing_it_wrong' ) ) :
 			sprintf(
 			/* translators: 1: The REST API route namespace, 2: The plugin version. */
 				__( 'All custom menu routes under %1$s are deprecated in WordPress >= 5.9. Please use WordPres cores menu route(s).' ),
-				'<code>' . self::get_plugin_namespace() . '</code>'
+				'<code>' . WP_REST_Menus::get_plugin_namespace() . '</code>'
 			),
 			'1.4.0'
 		);


### PR DESCRIPTION
## Release 1.4.0

* Final release before **complete** deprecation of `wp-api-menus/` route.
* Adds `_doing_it_wrong` for all routes (unless) the allowed filter is returned as true:
  ```php
    add_filter( 'rest_menus_allow_legacy_menus', '__return_true' );
    ``` 